### PR TITLE
hotfix: Webkit 기반 브라우저에서 폰트 굵기가 올바르게 렌더링되지 않는 현상 수정

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -8,6 +8,7 @@ import { cn } from '@aics/ui/lib/utils'
 const wantedSans = localFont({
   src: '../public/fonts/wanted-sans-variable.woff2',
   display: 'swap',
+  weight: '400 950',
 })
 
 export const metadata: Metadata = {


### PR DESCRIPTION
## Summary

> Webkit 기반의 브라우저에서 가변폰트의 굵기가 제대로 출력되지 않는 현상을 수정합니다.

## Tasks

- layout.tsx의 localFont 설정에 weight를 명시합니다.